### PR TITLE
Python: Fix python syntax

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 200

--- a/defaults.py
+++ b/defaults.py
@@ -16,7 +16,7 @@ def _writefile(modulename: str):
         [
             "oslopolicy-policy-generator",
             "--namespace", modulename,
-            "--output-file", base_path / "default_policies.yaml"
+            "--output-file", basepath / "default_policies.yaml"
         ],
         capture_output=True,
     )


### PR DESCRIPTION
Fix typo in default.py. Add .flake8 for linelength exeption.

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
